### PR TITLE
refactor(io): implement direct IO actions and add IO golden tests

### DIFF
--- a/ZikuTest.lean
+++ b/ZikuTest.lean
@@ -28,7 +28,7 @@ def runPhase (phase : String) (input : String) : IO Unit := do
         | .error e =>
           IO.println s!"Translation error: {e}"
         | .ok stmt =>
-          let result := Ziku.IR.eval stmt
+          let result ← Ziku.IR.eval stmt
           match result with
           | .value p _ => IO.println (Ziku.IR.truncate p.toString)
           | .stuck s _ => IO.println s!"Stuck: {s}"

--- a/tests/golden/io/success/print_simple.golden
+++ b/tests/golden/io/success/print_simple.golden
@@ -1,0 +1,3 @@
+Hello
+World
+()

--- a/tests/golden/io/success/print_simple.ziku
+++ b/tests/golden/io/success/print_simple.ziku
@@ -1,0 +1,2 @@
+let x = println("Hello") in
+println("World")

--- a/tests/golden/io/success/readline_simple.golden
+++ b/tests/golden/io/success/readline_simple.golden
@@ -1,0 +1,2 @@
+Name: Hello, ZikuUser
+()

--- a/tests/golden/io/success/readline_simple.input
+++ b/tests/golden/io/success/readline_simple.input
@@ -1,0 +1,1 @@
+ZikuUser

--- a/tests/golden/io/success/readline_simple.ziku
+++ b/tests/golden/io/success/readline_simple.ziku
@@ -1,0 +1,2 @@
+let name = readLine("Name: ") in
+println("Hello, " ++ name)


### PR DESCRIPTION
Refactors the interpreter to use the IO monad, enabling direct IO actions like 'println' and 'readLine'.

Changes:
- Refactored 'Ziku.IR.Eval.eval' to return 'IO EvalResult'.
- Implemented 'println' and 'readLine' builtins.
- Updated 'Main.lean' and 'tests/TestRunner.lean' to handle monadic evaluation.
- Added comprehensive IO golden tests.

Closes #16