### PR TITLE
fix(ci): install chezscheme in lake-update workflow

### DIFF
--- a/.github/workflows/lake-update.yml
+++ b/.github/workflows/lake-update.yml
@@ -43,6 +43,9 @@ jobs:
             echo "No updates available."
           fi
 
+      - name: Install Chez Scheme
+        run: sudo apt-get update && sudo apt-get install -y chezscheme
+
       - name: Build and test with updated dependencies
         if: steps.update.outputs.has_updates == 'true'
         run: |


### PR DESCRIPTION
## Summary
This PR fixes the CI failure in the **Lake Dependency Update** workflow.

## The Problem
The `lake-update.yml` workflow was failing because it attempts to run `lake test`, which requires `chezscheme` to be installed. However, the workflow configuration was missing the installation step for Chez Scheme (unlike `lean_action_ci.yml`).

## The Fix
Added the install step for Chez Scheme:
```yaml
      - name: Install Chez Scheme
        run: sudo apt-get update && sudo apt-get install -y chezscheme
```
