### PR TITLE
feat(skill): update issue skill to use GitHub Issues

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,32 +1,24 @@
 ---
 name: issue
-description: This skill should be used when the user asks to "create an issue", "write an issue", "add an issue", "log an issue", "report a bug", "document a problem", or wants to track tasks, bugs, or feature requests in the issues folder.
+description: This skill should be used when the user asks to "create an issue", "write an issue", "add an issue", "log an issue", "report a bug", "document a problem", or wants to track tasks, bugs, or feature requests as GitHub issues.
 ---
 
 # Issue Writing Guidelines
 
-Create and manage issues in the `issues/` folder at the project root.
+Create and manage issues using GitHub Issues via the `gh` CLI.
 
 ## Workflow
 
-1. Ensure the `issues/` folder exists (create if needed)
-2. Generate a unique filename using date and title
-3. Write the issue file with proper frontmatter
-4. Confirm the issue was created
+1. Gather information about the issue from the user or context
+2. Write the issue body to a temporary file (`/tmp/issue-body.md`)
+3. Create the issue using `gh issue create --title "..." --body-file /tmp/issue-body.md`
+4. Return the created issue URL to the user
 
-## Issue File Format
+## Issue Format
 
-Each issue is a Markdown file with YAML frontmatter:
+Use GitHub-flavored Markdown with the following structure:
 
 ```markdown
----
-date: YYYY-MM-DD
-title: <concise issue title>
-status: open
----
-
-# <Issue Title>
-
 ## Description
 
 <Detailed description of the issue, bug, or feature request>
@@ -34,30 +26,63 @@ status: open
 ## Context
 
 <Any relevant context, steps to reproduce, or background information>
+
+## Related Files
+
+- `path/to/file1`
+- `path/to/file2`
 ```
 
-## File Naming Convention
+## Creating Issues
 
-`issues/YYYY-MM-DD-<slug>.md`
+Always write the body to a temporary file first to avoid shell escaping issues:
 
-- Use the current date
-- Convert title to kebab-case slug
-- Keep slug under 50 characters
-- Use only lowercase letters, numbers, and hyphens
+```bash
+# Write body to tmp file (using Write tool)
+# Then create issue:
+gh issue create --title "Issue title" --body-file /tmp/issue-body.md
+```
 
-### Examples
+### With Labels
 
-- `issues/2025-12-27-fix-parser-crash.md`
-- `issues/2025-12-27-add-type-annotations.md`
-- `issues/2025-12-27-improve-error-messages.md`
+```bash
+gh issue create --title "Bug: Parser crash" --body-file /tmp/issue-body.md --label bug
+```
 
-## Status Values
+### With Assignees
 
-| Status | Meaning |
-|--------|---------|
-| `open` | New issue, not yet addressed |
-| `in-progress` | Currently being worked on |
-| `closed` | Issue resolved or no longer relevant |
+```bash
+gh issue create --title "Feature request" --body-file /tmp/issue-body.md --assignee @me
+```
+
+## Managing Issues
+
+### List Issues
+
+```bash
+gh issue list
+gh issue list --state open
+gh issue list --label bug
+```
+
+### View Issue
+
+```bash
+gh issue view 123
+```
+
+### Close Issue
+
+```bash
+gh issue close 123
+gh issue close 123 --comment "Fixed in commit abc123"
+```
+
+### Add Comment
+
+```bash
+gh issue comment 123 --body "Progress update: ..."
+```
 
 ## Writing Good Issue Descriptions
 
@@ -66,18 +91,14 @@ status: open
 - Mention expected vs actual behavior
 - Reference related files or code when relevant
 - Keep descriptions focused and actionable
+- Use code blocks for error messages and code snippets
 
 ## Example Issue
 
+**Title:** Parser fails on empty input
+
+**Body:**
 ```markdown
----
-date: 2025-12-27
-title: Parser fails on empty input
-status: open
----
-
-# Parser fails on empty input
-
 ## Description
 
 The parser crashes with an index out of bounds error when given an empty string as input.
@@ -93,4 +114,9 @@ The parser crashes with an index out of bounds error when given an empty string 
 
 1. Run `ziku parse ""`
 2. Observe the crash
+
+## Related Files
+
+- `Ziku/Parser.lean`
+- `Ziku/Lexer.lean`
 ```


### PR DESCRIPTION
## Summary

- Update issue skill to use GitHub Issues instead of local file tracking
- Use `gh` CLI for issue management (create, list, view, close, comment)
- Write issue body to temp file to avoid shell escaping issues

## Test plan

- [x] Verified skill works by creating issue #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
