### PR TITLE
fix(renovate): add RENOVATE_REPOSITORIES to specify target repository

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -32,6 +32,8 @@ jobs:
           configurationFile: .github/renovate.json
           token: ${{ steps.generate-token.outputs.token }}
         env:
+          # Specify which repository to scan
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           # Enable repository caching for better performance
           RENOVATE_REPOSITORY_CACHE: "enabled"
           # Set log level (use 'debug' for initial troubleshooting)


### PR DESCRIPTION
## 問題

Renovateワークフローが実行されても何も実行されず、以下の警告が出ていました：

```
WARN: No repositories found - did you want to run with flag --autodiscover?
```

## 原因

GitHub App認証を使用する場合、`renovatebot/github-action`はデフォルトでリポジトリを自動検出しません。明示的に`RENOVATE_REPOSITORIES`環境変数でスキャン対象を指定する必要があります。

## 変更内容

`.github/workflows/renovate.yml`に以下を追加：

```yaml
env:
  RENOVATE_REPOSITORIES: ${{ github.repository }}
```

これにより、Renovateは`takoeight0821/ziku`リポジトリをスキャンし、依存関係の更新を検出できるようになります。

## 検証方法

マージ後、手動でRenovateワークフローを実行：
1. Actions → Renovate → Run workflow
2. 今度はリポジトリをスキャンし、Dependency DashboardやPRが作成されるはず

## 関連

- Issue #25
- 初回セットアップPR: #29