### PR TITLE
feat(deps): add Renovate tracking for apt packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,25 @@
       "matchManagers": ["git-submodules"],
       "groupName": "Git submodules",
       "automerge": false
+    },
+    {
+      "matchManagers": ["regex"],
+      "matchDatasources": ["deb"],
+      "groupName": "APT packages",
+      "automerge": false,
+      "description": "Group all apt package updates into single PR for easier review"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=deb depName=(?<depName>[^\\s]+)\\nARG [A-Z0-9_]+_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "deb",
+      "versioningTemplate": "deb",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble&components=main,universe"
     }
   ],
   "ignorePaths": ["**/vendor/**"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,32 @@ FROM --platform=linux/amd64 ubuntu:24.04
 # Install system dependencies including Chez Scheme
 #
 # Dependency Management Strategy:
-# - No version pinning to allow security updates from Ubuntu 24.04 LTS
-# - Ubuntu LTS provides API stability guarantees until 2029
-# - Current versions (as of Jan 2026):
-#   - ca-certificates: SSL/TLS certificates for HTTPS connections
-#   - curl: HTTP client for downloading resources
-#   - git: Version control, required by Lake
-#   - build-essential: GCC/G++ toolchain (12.x)
-#   - python3: Build system utilities (3.12.x)
-#   - chezscheme: Scheme compiler for backend (10.0.0)
+# - Version pinning enabled for Renovate tracking (Jan 2026)
+# - Automated updates via Renovate with manual PR review
+# - Ubuntu 24.04 LTS provides API stability guarantees until 2029
+# - Trade-off: Security visibility + audit trail vs absolute flexibility
 #
-# Trade-off: Security updates prioritized over absolute reproducibility
-# For pinned builds, use --build-arg with specific versions
+# APT package versions tracked by Renovate (deb datasource, suite=noble)
+# renovate: datasource=deb depName=ca-certificates
+ARG CA_CERTIFICATES_VERSION=20240203
+# renovate: datasource=deb depName=curl
+ARG CURL_VERSION=8.5.0-2ubuntu10.6
+# renovate: datasource=deb depName=git
+ARG GIT_VERSION=1:2.43.0-1ubuntu7.3
+# renovate: datasource=deb depName=build-essential
+ARG BUILD_ESSENTIAL_VERSION=12.10ubuntu1
+# renovate: datasource=deb depName=python3
+ARG PYTHON3_VERSION=3.12.3-0ubuntu2.1
+# renovate: datasource=deb depName=chezscheme
+ARG CHEZSCHEME_VERSION=9.5.8+dfsg-1
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    git \
-    build-essential \
-    python3 \
-    chezscheme \
+    ca-certificates=${CA_CERTIFICATES_VERSION} \
+    curl=${CURL_VERSION} \
+    git=${GIT_VERSION} \
+    build-essential=${BUILD_ESSENTIAL_VERSION} \
+    python3=${PYTHON3_VERSION} \
+    chezscheme=${CHEZSCHEME_VERSION} \
     && rm -rf /var/lib/apt/lists/*
 
 # Install elan (Lean 4 version manager)


### PR DESCRIPTION
## 概要

DockerfileのaptパッケージをRenovateで追跡できるようにします。

## 変更内容

### Dockerfile
- 6つのaptパッケージにバージョンピン留めを追加
  - ca-certificates: 20240203
  - curl: 8.5.0-2ubuntu10.6
  - git: 1:2.43.0-1ubuntu7.3
  - build-essential: 12.10ubuntu1
  - python3: 3.12.3-0ubuntu2.1
  - chezscheme: 9.5.8+dfsg-1
- ARG変数とRenovateメタデータコメントを追加

### renovate.json
- `deb` datasourceを使用したcustomManagersを追加
- Ubuntu 24.04 (noble) リポジトリを参照
- 全aptパッケージを「APT packages」グループにまとめて1つのPRで更新

## トレードオフ

**メリット:**
- セキュリティ更新の可視性
- バージョン履歴の監査証跡
- 週次の自動更新チェック
- グループ化されたPRで効率的なレビュー

**デメリット:**
- Dockerfileの複雑化（ARG変数追加）
- リポジトリからバージョンが削除された場合のビルド失敗リスク
- 月1回程度のPRレビュー負荷

## テスト計画

- [ ] Dockerビルドが成功すること
- [ ] Renovateがaptパッケージを検出すること（Dependency Dashboard確認）
- [ ] 更新があればPRが作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)