### PR TITLE
chore(ci): pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver-opts: |
             image=moby/buildkit:latest

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Cache elan
-        uses: actions/cache@v5
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ~/.elan
           key: ${{ runner.os }}-elan-${{ hashFiles('lean-toolchain') }}
@@ -32,7 +32,7 @@ jobs:
         run: lake --version
 
       - name: Cache Lake build
-        uses: actions/cache@v5
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: .lake
           key: ${{ runner.os }}-lake-${{ hashFiles('lake-manifest.json', 'lakefile.lean') }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Generate GitHub App token
         id: generate-token
@@ -27,7 +27,7 @@ jobs:
           repositories: ziku
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v44.2.2
+        uses: renovatebot/github-action@8b7941943a108b2cc2150730963164aa8baeab8c # v44.2.2
         with:
           configurationFile: .github/renovate.json
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Check for Lean toolchain updates
         id: check
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check.outputs.updated == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update lean toolchain to ${{ steps.check.outputs.version }}"
@@ -60,13 +60,13 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Install Chez Scheme
         run: sudo apt-get update && sudo apt-get install -y chezscheme
 
       - name: Setup Lean
-        uses: leanprover/lean-action@v1
+        uses: leanprover/lean-action@434f25c2f80ded67bba02502ad3a86f25db50709 # v1.3.0
         with:
           build: false
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.update.outputs.has_updates == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(deps): update Lake dependencies"
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Check for elan updates
         id: check
@@ -139,7 +139,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check.outputs.updated == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update elan to ${{ steps.check.outputs.version }}"


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full SHA digests for improved supply chain security
- Each action includes a version comment for readability (e.g., `@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1`)
- Pinned actions in: `docker-ci.yml`, `lean_action_ci.yml`, `renovate.yml`, `update-dependencies.yml`

## Test plan
- [ ] Verify CI workflows run successfully with pinned actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)