### PR TITLE
docs: update documentation for Nix-based Docker architecture

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -6,12 +6,12 @@ Implementation details for developers and contributors.
 
 ```
 Ziku/
-├── Syntax.lean         # Shared types: SourcePos, Ident, Lit, BinOp, Pat, Ty
-├── Surface/
-│   └── Syntax.lean     # Surface AST with label/goto
+├── Syntax.lean         # AST types: SourcePos, Ident, Lit, BinOp, Pat, Ty, Expr
+├── Builtins.lean       # Built-in function definitions
 ├── IR/
 │   ├── Syntax.lean     # Sequent calculus IR (Producer, Consumer, Statement)
-│   └── Eval.lean       # IR evaluator with μ/μ̃-reduction
+│   ├── Eval.lean       # IR evaluator with μ/μ̃-reduction
+│   └── Focusing.lean   # Focusing transformation
 ├── Backend/
 │   └── Scheme.lean     # Scheme code generator (CPS translation)
 ├── Translate.lean      # Surface → IR translation
@@ -19,7 +19,9 @@ Ziku/
 ├── Parser.lean         # Recursive descent parser
 ├── Type.lean           # Type utilities: Subst, Scheme
 ├── Infer.lean          # HM type inference
-└── Proofs/             # Lean proofs (Arithmetic, Eval, Identities, Soundness)
+├── Elaborate.lean      # Codata elaboration
+├── Soundness.lean      # Type soundness proofs
+└── Proofs/             # Lean proofs (Arithmetic, Eval, Identities)
 ```
 
 ## Pipeline
@@ -145,15 +147,20 @@ This allows runtime checks to properly evaluate thunks when needed.
 Golden tests are in `tests/golden/`:
 
 - `parser/`: Parser output tests (.ziku → .golden)
-- `eval/`: Surface language evaluation tests
 - `infer/`: Type inference tests
 - `ir-eval/`: IR evaluation tests (via translation)
+- `io/`: I/O tests
+- `scheme/`: Scheme backend tests
+- `scheme-only/`: Scheme-only tests (no IR evaluation)
 
 ### Adding Tests
 
-1. Create `tests/golden/{category}/{name}.ziku`
-2. Add test name to `tests/GoldenTest.lean`
-3. Run `lake test` to auto-generate `.golden` file
+Tests are auto-discovered from `.ziku` files:
+
+1. Create `tests/golden/{category}/{success|error}/{name}.ziku`
+2. Run `lake test` to auto-generate `.golden` file
+
+No manual registration required.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ A functional programming language exploring the duality between data and codata.
 
 ## Quick Start
 
+### Docker (Recommended)
+
+No local dependencies required:
+
+```bash
+docker build -t ziku .                                        # Build image
+docker run --rm -it ziku nix develop --command lake exe ziku  # Run REPL
+docker run --rm ziku nix develop --command lake test          # Run tests
+```
+
+### Native
+
+Requires [Lean 4](https://lean-lang.org/) and [Chez Scheme](https://cisco.github.io/ChezScheme/):
+
 ```bash
 lake build         # Build
 lake exe ziku      # Run REPL
@@ -64,58 +78,57 @@ label done {
 
 ### Dependency Management
 
-このプロジェクトは、依存関係の自動更新にRenovateを使用しています。
+This project uses Renovate for automated dependency updates and Nix flakes for reproducible builds.
 
-**Renovateのセットアップ（メンテナー向け）:**
+**Renovate Setup (for maintainers):**
 
-1. **GitHub Appを作成**
+1. **Create a GitHub App**
 
    GitHub Settings → Developer settings → GitHub Apps → **New GitHub App**
 
-   必要な設定：
-   - **GitHub App name**: `renovate-ziku`（または任意の名前）
+   Required settings:
+   - **GitHub App name**: `renovate-ziku` (or any name)
    - **Homepage URL**: `https://github.com/takoeight0821/ziku`
-   - **Webhook**: "Active" のチェックを**外す**
+   - **Webhook**: Uncheck "Active"
 
-   **Repository permissions**（以下を全て設定）:
+   **Repository permissions** (set all of the following):
    - Checks: Read and write
    - Contents: Read and write
    - Commit statuses: Read and write
    - Issues: Read and write
    - Pull requests: Read and write
    - Workflows: Read and write
-   - Metadata: Read only（自動設定）
+   - Metadata: Read only (auto-set)
 
-   作成後：
-   - **App ID**をメモ（後で使用）
-   - **Generate a private key**をクリックして `.pem` ファイルをダウンロード
+   After creation:
+   - Note the **App ID** (needed later)
+   - Click **Generate a private key** to download the `.pem` file
 
-2. **Appをリポジトリにインストール**
+2. **Install the App to the repository**
 
-   作成したGitHub Appのページから：
-   - **Install App** → **Only select repositories** → `takoeight0821/ziku` を選択
-   - インストール後のURLから **Installation ID** を取得
-     - 例: `https://github.com/settings/installations/12345678` の `12345678` 部分
+   From the GitHub App page:
+   - **Install App** → **Only select repositories** → Select `takoeight0821/ziku`
+   - Get the **Installation ID** from the URL after installation
+     - Example: `12345678` from `https://github.com/settings/installations/12345678`
 
-3. **GitHub Actionsにシークレットを追加**
+3. **Add secrets to GitHub Actions**
 
    Repository Settings → Secrets and variables → Actions → **New repository secret**:
-   - `RENOVATE_APP_ID`: 手順1でメモしたApp ID
-   - `RENOVATE_APP_PRIVATE_KEY`: ダウンロードした `.pem` ファイルの内容全体
+   - `RENOVATE_APP_ID`: The App ID from step 1
+   - `RENOVATE_APP_PRIVATE_KEY`: The entire contents of the downloaded `.pem` file
 
-4. **動作確認**
+4. **Verify**
 
-   Actions → Renovate → **Run workflow** で手動実行
+   Actions → Renovate → **Run workflow** to trigger manually
 
-**自動更新される依存関係:**
-- GitHub Actions（週次、月曜 9:00 UTC）
-- Docker base images
+**Auto-updated dependencies:**
+- GitHub Actions (weekly, Mondays 9:00 UTC)
+- Nix flake inputs (nixpkgs, flake-utils)
 - Git submodules
 - Lean toolchain
 - Lake dependencies
-- elanバージョン
 
-詳細は[CLAUDE.md](CLAUDE.md)を参照してください。
+See [CLAUDE.md](CLAUDE.md) for detailed dependency management information.
 
 ## Background
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,14 +2,28 @@
 
 This guide will help you set up Ziku and run your first program.
 
-## Prerequisites
-
-- [Lean 4](https://lean-lang.org/) (version 4.x)
-- [Lake](https://github.com/leanprover/lake) (included with Lean 4)
-
 ## Installation
 
-Clone the repository and build:
+### Docker (Recommended)
+
+The easiest way to get started - no local dependencies required:
+
+```bash
+git clone https://github.com/takoeight0821/ziku.git
+cd ziku
+docker build -t ziku .
+```
+
+This may take a few minutes on first build.
+
+### Native (Alternative)
+
+If you prefer a native installation:
+
+**Prerequisites:**
+- [Lean 4](https://lean-lang.org/) (version 4.x)
+- [Lake](https://github.com/leanprover/lake) (included with Lean 4)
+- [Chez Scheme](https://cisco.github.io/ChezScheme/) (for Scheme backend)
 
 ```bash
 git clone https://github.com/takoeight0821/ziku.git
@@ -19,7 +33,13 @@ lake build
 
 ## Running the REPL
 
-Start the interactive REPL:
+### Docker
+
+```bash
+docker run --rm -it ziku nix develop --command lake exe ziku
+```
+
+### Native
 
 ```bash
 lake exe ziku
@@ -35,6 +55,20 @@ You'll see a prompt where you can type expressions:
 ```
 
 Type `Ctrl+D` or `Ctrl+C` to exit.
+
+## Running Tests
+
+### Docker
+
+```bash
+docker run --rm ziku nix develop --command lake test
+```
+
+### Native
+
+```bash
+lake test
+```
 
 ## Your First Program
 


### PR DESCRIPTION
## Summary

- Add Docker-first quick start instructions to README.md and getting-started.md
- Translate README.md dependency management section from Japanese to English
- Fix INTERNALS.md architecture diagram to match actual codebase structure
- Update test documentation to reflect auto-discovery and correct categories

## Test plan

- [ ] Verify Docker commands work as documented
- [ ] Verify all documentation links are valid
- [ ] Check that architecture diagram matches `Ziku/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)