### PR TITLE
feat(skills): add lean4-conventions, add-golden-test, proof-writing skills

### DIFF
--- a/.agent/skills/add-golden-test/SKILL.md
+++ b/.agent/skills/add-golden-test/SKILL.md
@@ -1,0 +1,164 @@
+---
+description: Add golden tests to the Ziku test suite. Use when user asks to "add a test", "create a golden test", "test this expression", "add regression test", or "try a simpler case".
+---
+
+# Adding Golden Tests
+
+Golden tests compare actual output against expected output stored in `.golden` files.
+
+## Quick Start
+
+1. Create test file: `tests/golden/{category}/{success|error}/{name}.ziku`
+2. Run `lake test` to auto-generate `.golden` file
+3. Verify the generated `.golden` file is correct
+4. Commit both `.ziku` and `.golden` files
+
+## Test Categories
+
+| Category | Purpose | Example Use Case |
+|----------|---------|------------------|
+| `parser` | Parser output | Syntax edge cases, error recovery |
+| `infer` | Type inference | Polymorphism, record types, error messages |
+| `ir-eval` | IR interpreter | Expression evaluation, recursion |
+| `scheme` | Scheme codegen | Code generation correctness |
+| `scheme-only` | Direct Scheme execution | Scheme runtime behavior |
+| `io` | IO operations | Print, input handling |
+| `truncate` | Truncated evaluation | Big-step semantics testing |
+| `big-step` | Big-step semantics | Alternative evaluator |
+| `consistency` | Cross-evaluator consistency | Same result across evaluators |
+
+## Directory Structure
+
+```
+tests/golden/
+├── parser/
+│   ├── success/       # Valid syntax tests
+│   │   ├── simple.ziku
+│   │   └── simple.golden
+│   └── error/         # Parse error tests
+│       ├── missing-paren.ziku
+│       └── missing-paren.golden
+├── infer/
+│   ├── success/       # Type inference success
+│   └── error/         # Type errors
+├── ir-eval/
+│   ├── success/       # Evaluation tests
+│   └── error/         # Runtime errors
+└── ...
+```
+
+## Workflow
+
+### Adding a Success Test
+
+```bash
+# 1. Create test file
+echo 'let x = 1 in x + 1' > tests/golden/ir-eval/success/simple-let.ziku
+
+# 2. Run tests to generate golden file
+lake test -- ir-eval
+
+# 3. Check generated golden file
+cat tests/golden/ir-eval/success/simple-let.golden
+# Output: 2
+
+# 4. If correct, commit both files
+```
+
+### Adding an Error Test
+
+```bash
+# 1. Create test file with expected-to-fail code
+echo 'let x = true in x + 1' > tests/golden/infer/error/type-mismatch.ziku
+
+# 2. Run tests to generate golden file
+lake test -- infer
+
+# 3. Verify error message is correct
+cat tests/golden/infer/error/type-mismatch.golden
+# Output: Type error: expected Int, got Bool
+
+# 4. Commit both files
+```
+
+### Debugging with Simpler Cases
+
+When debugging complex issues, add a simpler test case:
+
+```bash
+# Original failing case is complex
+# Add simpler reproduction
+echo '\x => x' > tests/golden/infer/success/identity-simple.ziku
+lake test -- infer
+```
+
+## Test Execution Commands
+
+```bash
+# Run all tests
+lake test
+
+# Run specific category (faster feedback)
+lake test -- parser
+lake test -- infer
+lake test -- ir-eval
+
+# Run multiple categories
+lake test -- parser infer
+
+# Parallel execution (recommended for full runs)
+make -j4 test-parallel
+
+# Fast tests only (parser, infer, truncate, big-step)
+make -j4 test-fast
+
+# Show available categories
+lake test -- --help
+```
+
+## Writing Effective Tests
+
+### Good Test Characteristics
+
+- **Minimal**: Smallest code that demonstrates the behavior
+- **Focused**: Tests one thing at a time
+- **Named descriptively**: `record-projection.ziku`, not `test1.ziku`
+
+### Test Naming Convention
+
+```
+{feature}-{variant}.ziku
+
+Examples:
+- let-simple.ziku
+- let-nested.ziku
+- let-polymorphic.ziku
+- function-application.ziku
+- function-higher-order.ziku
+```
+
+### Testing Edge Cases
+
+| Feature | Edge Cases to Test |
+|---------|-------------------|
+| Arithmetic | Negative numbers, zero, large numbers |
+| Functions | Currying, partial application, recursion |
+| Records | Empty record, single field, nested |
+| Pattern match | Exhaustiveness, nested patterns |
+| Polymorphism | Instantiation, let-polymorphism |
+
+## Checklist
+
+When adding a golden test:
+
+- [ ] Chose appropriate category
+- [ ] Used descriptive file name
+- [ ] Test is minimal (no unnecessary code)
+- [ ] Verified `.golden` file content is correct
+- [ ] Committed both `.ziku` and `.golden` files
+
+## References
+
+- [CLAUDE.md#testing](../../CLAUDE.md) - Testing overview
+- [tests/golden/](../../tests/golden/) - Existing tests as examples
+- [/test skill](../test/SKILL.md) - Interactive testing workflow

--- a/.agent/skills/lean4-conventions/SKILL.md
+++ b/.agent/skills/lean4-conventions/SKILL.md
@@ -1,0 +1,171 @@
+---
+description: Lean 4 coding conventions for Ziku. Use when writing new Lean code, reviewing implementations, or deciding between `partial` functions vs termination proofs.
+---
+
+# Lean 4 Conventions for Ziku
+
+This skill covers Lean 4 coding patterns and conventions specific to the Ziku project.
+
+## `partial` vs Termination Proofs
+
+### When to Use `partial`
+
+Use `partial def` when:
+- Termination depends on runtime values that are hard to prove decreasing
+- The function is used only for computation, not in proofs
+- Implementing interpreters, evaluators, or parsers
+
+```lean
+-- OK: Interpreter where termination depends on program behavior
+partial def eval (stmt : Statement) : IO Value := ...
+
+-- OK: Parser with complex backtracking
+partial def parseExpr : Parser Expr := ...
+```
+
+### Alternatives to `partial`
+
+Consider these before using `partial`:
+
+1. **`termination_by` clause**: When a decreasing measure exists
+   ```lean
+   def factorial (n : Nat) : Nat :=
+     if n = 0 then 1 else n * factorial (n - 1)
+   termination_by n
+   ```
+
+2. **Fuel parameter**: Bounded execution with explicit limit
+   ```lean
+   def evalWithFuel (fuel : Nat) (stmt : Statement) : Option Value :=
+     match fuel with
+     | 0 => none
+     | n + 1 => ... evalWithFuel n ...
+   ```
+
+3. **Step-based execution**: Return intermediate state
+   ```lean
+   def step (state : State) : State ⊕ Value := ...
+   ```
+
+### Trade-offs
+
+| Approach | Proofs | Performance | Complexity |
+|----------|--------|-------------|------------|
+| `partial` | ❌ Cannot prove properties | ✅ Best | ✅ Simple |
+| `termination_by` | ✅ Full proofs | ✅ Best | ⚠️ Need measure |
+| Fuel | ⚠️ Limited (bounded) | ⚠️ May timeout | ⚠️ Extra parameter |
+| Step-based | ✅ Per-step proofs | ⚠️ Overhead | ⚠️ State management |
+
+## Mutual Recursion
+
+### Use Explicit Function Calls
+
+In mutual recursive functions, use explicit function calls instead of dot notation:
+
+```lean
+-- ❌ WRONG: Dot notation in mutual recursion can cause issues
+mutual
+  def Producer.eval (prod : Producer) : ... :=
+    match prod with
+    | .cut p c => c.eval p  -- DON'T do this
+
+  def Consumer.eval (cons : Consumer) (prod : Producer) : ... := ...
+end
+
+-- ✅ CORRECT: Explicit function calls
+mutual
+  def Producer.eval (prod : Producer) : ... :=
+    match prod with
+    | .cut p c => Consumer.eval c p  -- DO this
+
+  def Consumer.eval (cons : Consumer) (prod : Producer) : ... := ...
+end
+```
+
+### Substitution Pattern
+
+For substitution in IR, use explicit calls consistently:
+
+```lean
+def Producer.substVar (x : String) (p : Producer) (prod : Producer) : Producer :=
+  match prod with
+  | .cut prod cons =>
+    .cut (Producer.substVar x p prod) (Consumer.substVar x p cons)
+  | ...
+
+def Consumer.substVar (x : String) (p : Producer) (cons : Consumer) : Consumer :=
+  match cons with
+  | .mu x' stmt =>
+    if x == x' then cons
+    else .mu x' (Statement.substVar x p stmt)
+  | ...
+```
+
+## Source Position Tracking
+
+Track source positions throughout the AST for error reporting:
+
+```lean
+structure Pos where
+  line : Nat
+  column : Nat
+
+structure Located (α : Type) where
+  pos : Pos
+  val : α
+
+-- Use Located for AST nodes
+inductive Expr where
+  | var (name : Located String)
+  | app (fn : Located Expr) (arg : Located Expr)
+  | ...
+```
+
+Error messages should include position information:
+
+```lean
+def formatError (pos : Pos) (msg : String) : String :=
+  s!"{pos.line}:{pos.column}: {msg}"
+```
+
+## Naming Conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Types | PascalCase | `Producer`, `Consumer`, `Statement` |
+| Functions | camelCase | `evalStmt`, `substVar`, `translateExpr` |
+| Theorems | snake_case | `eval_deterministic`, `subst_preserves_type` |
+| Namespaces | PascalCase | `Ziku.IR.Eval` |
+| Local variables | camelCase | `stmt`, `prodVal`, `consEnv` |
+
+## Module Organization
+
+```
+Ziku/
+├── Syntax.lean       -- Surface language AST
+├── Parser.lean       -- Hand-written parser
+├── Infer.lean        -- Type inference
+├── Translate.lean    -- Surface → IR translation
+├── IR/
+│   ├── Syntax.lean   -- IR AST (Producer, Consumer, Statement)
+│   ├── Eval.lean     -- IR interpreter
+│   └── Emit.lean     -- Scheme code generation
+└── Proofs/
+    └── IR/           -- IR-related proofs
+```
+
+## Checklist
+
+When writing new Lean code:
+
+- [ ] Consider termination: Can you prove it? Is `partial` acceptable?
+- [ ] Use explicit function calls in mutual recursion
+- [ ] Track source positions for user-facing errors
+- [ ] Follow naming conventions
+- [ ] Place code in appropriate module
+
+## References
+
+- [CLAUDE.md](../../CLAUDE.md) - Project conventions
+- [Ziku/IR/](../../Ziku/IR/) - IR implementation examples
+- [Ziku/Proofs/](../../Ziku/Proofs/) - Proof examples

--- a/.agent/skills/proof-writing/SKILL.md
+++ b/.agent/skills/proof-writing/SKILL.md
@@ -1,0 +1,196 @@
+---
+description: Write proofs in Lean 4 for Ziku. Use when user asks to "prove", "add a lemma", "verify property", "formalize", or when modifying files in Ziku/Proofs/.
+---
+
+# Proof Writing for Ziku
+
+Guidelines for writing proofs in the Ziku codebase.
+
+## Proofs Directory Structure
+
+```
+Ziku/Proofs/
+├── Arithmetic.lean    -- Arithmetic operation properties
+├── Eval.lean          -- Evaluation properties
+├── Identities.lean    -- Basic identities
+├── Soundness.lean     -- Type soundness (limited by partial)
+└── IR/
+    ├── Evaluation.lean   -- IR evaluation properties
+    ├── Semantics.lean    -- Operational semantics
+    ├── Substitution.lean -- Substitution lemmas
+    └── Values.lean       -- Value properties
+```
+
+## The `partial` Limitation
+
+**Critical**: Functions marked `partial` cannot be used in proofs.
+
+```lean
+-- This is marked partial
+partial def eval (stmt : Statement) : IO Value := ...
+
+-- Therefore, you CANNOT prove properties about eval directly
+-- ❌ theorem eval_deterministic : eval s₁ = eval s₂ → s₁ = s₂ := by ...
+```
+
+### Workarounds
+
+1. **Fuel-based version for proofs**:
+   ```lean
+   -- Define a fuel-based version
+   def evalFuel (fuel : Nat) (stmt : Statement) : Option Value := ...
+
+   -- Prove properties about evalFuel
+   theorem evalFuel_deterministic (h : evalFuel n s = some v₁)
+       (h' : evalFuel n s = some v₂) : v₁ = v₂ := by ...
+   ```
+
+2. **Step-based small-step semantics**:
+   ```lean
+   -- Define single-step reduction
+   inductive Step : Statement → Statement → Prop where
+     | mu_reduce : Step (cut (mu α s) c) (s.substCovar α c)
+     | ...
+
+   -- Prove properties about Step
+   theorem step_deterministic (h₁ : Step s s₁) (h₂ : Step s s₂) : s₁ = s₂ := by ...
+   ```
+
+3. **Prove properties about syntax/substitution** (no `partial` involved):
+   ```lean
+   -- Substitution doesn't use partial
+   theorem subst_twice (x : String) (p q : Producer) (prod : Producer) :
+       (prod.substVar x p).substVar x q = prod.substVar x q := by ...
+   ```
+
+## Proof Style Guidelines
+
+### Use Tactic Proofs
+
+```lean
+-- ✅ Preferred: Tactic proof
+theorem lookup_some_mem (h : l.lookup k = some v) :
+    k ∈ l.map Prod.fst := by
+  induction l with
+  | nil => simp [List.lookup] at h
+  | cons head tail ih =>
+    simp [List.lookup] at h
+    split at h
+    · rename_i heq
+      simp [List.mem_map]
+      left
+      exact LawfulBEq.eq_of_beq heq
+    · right
+      exact ih h
+
+-- ⚠️ Term-mode proofs are acceptable for simple cases
+theorem trivial_id : ∀ x, x = x := fun _ => rfl
+```
+
+### Structure Complex Proofs
+
+```lean
+theorem complex_property : P := by
+  -- Step 1: Establish preconditions
+  have h1 : Q := by
+    ...
+
+  -- Step 2: Apply main lemma
+  have h2 : R := main_lemma h1
+
+  -- Step 3: Conclude
+  exact final_step h2
+```
+
+### Use `sorry` Carefully
+
+```lean
+-- ✅ OK during development, with explanation
+theorem wip_property : P := by
+  sorry -- TODO: Need to prove Q first, see issue #123
+
+-- ❌ Never commit sorry without explanation
+theorem mystery : P := by
+  sorry
+```
+
+## Common Proof Patterns
+
+### Induction on AST
+
+```lean
+theorem subst_preserves (p : Producer) :
+    P (p.substVar x q) := by
+  induction p with
+  | var name =>
+    simp [Producer.substVar]
+    split <;> simp [*]
+  | cut prod cons ih_prod ih_cons =>
+    simp [Producer.substVar]
+    constructor
+    · exact ih_prod
+    · exact ih_cons
+  | ...
+```
+
+### Case Analysis
+
+```lean
+theorem eval_progress (stmt : Statement) :
+    IsValue stmt ∨ ∃ stmt', Step stmt stmt' := by
+  cases stmt with
+  | cut prod cons =>
+    cases prod with
+    | var x => ...
+    | mu α s => right; exact ⟨s.substCovar α cons, Step.mu_reduce⟩
+    | ...
+```
+
+### Decidability
+
+```lean
+instance : DecidableEq Producer := by
+  intro p₁ p₂
+  cases p₁ <;> cases p₂ <;>
+    try { right; intro h; injection h }
+  all_goals {
+    rename_i a b
+    exact if h : a = b then isTrue (by subst h; rfl)
+          else isFalse (by intro heq; injection heq; contradiction)
+  }
+```
+
+## Verification Checklist
+
+Before committing proofs:
+
+- [ ] No `sorry` without explanation
+- [ ] All theorems have meaningful names
+- [ ] Complex proofs are commented
+- [ ] `#check` succeeds for all theorems
+- [ ] Build succeeds: `lake build`
+
+After modifying `Ziku/Proofs/`:
+
+```bash
+# Verify no sorry in committed code
+grep -r "sorry" Ziku/Proofs/
+
+# Ensure build succeeds
+docker run --rm ziku lake build
+```
+
+## Naming Conventions
+
+| Kind | Pattern | Example |
+|------|---------|---------|
+| Lemma (helper) | `{property}_aux` | `subst_preserves_aux` |
+| Main theorem | `{subject}_{property}` | `eval_deterministic` |
+| Inverse | `{name}_inv` | `lookup_mem_inv` |
+| Composition | `{name}_comp` | `subst_comp` |
+
+## References
+
+- [Ziku/Proofs/](../../Ziku/Proofs/) - Existing proofs
+- [CLAUDE.md#verification-checklist](../../CLAUDE.md) - Verification requirements
+- [/lean4-conventions](../lean4-conventions/SKILL.md) - Lean 4 coding conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,7 @@ Golden tests in `tests/golden/`:
 - `infer/error/`: Type inference error tests
 - `ir-eval/success/`: IR evaluation tests (via translation)
 
-Tests are auto-discovered from `.ziku` files. Add new test by:
-
-1. Create `tests/golden/{category}/{success|error}/{name}.ziku`
-2. Run `lake test` to auto-generate `.golden` file
+Tests are auto-discovered from `.ziku` files. Use `/add-golden-test` skill for detailed workflow.
 
 ### Test Execution Options
 
@@ -105,11 +102,7 @@ Available categories: `truncate`, `big-step`, `parser`, `infer`, `ir-eval`, `ir-
 
 - Use conventional commit format for commit messages
 - The parser is hand-written due to Std.Internal.Parsec API issues
-- Use `partial` for recursive functions where termination is hard to prove
-  - **Alternatives to consider**: `termination_by` clause, fuel parameter, step-based execution
-  - **Trade-offs**: `partial def` enables practical implementation but cannot be used in proofs
-- Source positions are tracked throughout AST for error reporting
-- Use explicit function calls (e.g., `Producer.substVar x p prod`) instead of dot notation in mutual recursive functions
+- Use `/lean4-conventions` skill for detailed Lean 4 coding patterns (`partial` vs termination proofs, mutual recursion, naming)
 
 ## Verification Checklist
 
@@ -117,8 +110,8 @@ After making code changes, verify:
 
 1. **Build succeeds**: `docker run --rm ziku lake build`
 2. **All tests pass**: `docker run --rm ziku`
-3. **New features have tests**: Add corresponding golden tests in `tests/golden/`
-4. **Proofs are complete**: If `Proofs/` was modified, ensure no `sorry` remains
+3. **New features have tests**: Use `/add-golden-test` skill
+4. **Proofs are complete**: Use `/proof-writing` skill for guidelines
 
 ## Hints
 


### PR DESCRIPTION
## Summary
- Add `lean4-conventions` skill: Lean 4 coding patterns (`partial` vs termination proofs, mutual recursion, naming conventions)
- Add `add-golden-test` skill: Workflow for adding golden tests
- Add `proof-writing` skill: Guidelines for writing proofs in Ziku
- Update CLAUDE.md to reference skills instead of inline documentation

## Motivation
Improves context window efficiency by extracting detailed domain knowledge into on-demand skills.

Closes #50

## Test plan
- [x] Verify skills are recognized by Claude Code (`/lean4-conventions`, `/add-golden-test`, `/proof-writing`)
- [x] Confirm CLAUDE.md is more concise

🤖 Generated with [Claude Code](https://claude.com/claude-code)