### PR TITLE
chore(renovate): remove schedule restriction

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "config:recommended",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  "schedule": ["before 9am on Monday"],
   "timezone": "UTC",
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,


### PR DESCRIPTION
## Summary

Remove the `schedule` setting from Renovate configuration to allow PRs to be created at any time.

## Changes

- Remove `"schedule": ["before 9am on Monday"]` from `.github/renovate.json`

## Reason

The previous schedule restricted Renovate to only create PRs on Monday mornings (UTC). This prevented immediate updates when manually triggering the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)