### PR TITLE
refactor(skills): migrate commands to skills pattern

### DIFF
--- a/.agent/skills/research/SKILL.md
+++ b/.agent/skills/research/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: research
-description: Research a GitHub repository, software project, or academic paper in depth. Use when the user asks to "research", "investigate", "analyze", or "study" a repository, library, framework, programming language project, or academic paper. Produces a comprehensive markdown report saved to docs/research/.
-arguments:
-  - name: target
-    description: Repository (owner/repo), project name, paper title, or arXiv ID to research
-    required: true
+description: Research a GitHub repository, software project, or academic paper in depth. Use when the user asks to "research", "investigate", "analyze", "study", "調べて", or "調査" a repository (owner/repo format), library, framework, programming language project, academic paper (arXiv ID like 2301.12345, paper title, or "論文"), or technical topic. Takes a target argument (repository, project name, paper title, or arXiv ID). Produces a comprehensive markdown report saved to docs/research/.
 ---
 
 # Research: $ARGUMENTS.target

--- a/.agent/skills/translate/SKILL.md
+++ b/.agent/skills/translate/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: translate
 description: Translate documents, comments, or code documentation to Japanese. Use when the user asks to "translate", "translate to Japanese", "Japanese translation", or wants to convert English documentation, README files, code comments, or any text content to Japanese.
-arguments:
-  - name: target
-    description: File path to translate, or paste text directly
-    required: true
 ---
 
 # Translate to Japanese: $ARGUMENTS.target


### PR DESCRIPTION
## Summary
- `.claude/commands/` にあったコマンド定義を `.agent/skills/` パターンに移行
- `research` と `translate` コマンドを skills 構造に変換

## Changes
- `.claude/commands/research.md` → `.agent/skills/research/SKILL.md`
- `.claude/commands/translate.md` → `.agent/skills/translate/SKILL.md`

## Test plan
- [ ] `/research` スキルが正常に動作することを確認
- [ ] `/translate` スキルが正常に動作することを確認

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)